### PR TITLE
ci(workflows): harden permissions and use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -11,7 +11,6 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
-  packages: write
 
 jobs:
   release-please:
@@ -23,7 +22,7 @@ jobs:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   # The following jobs are executed only if a release is created
   build-and-publish:


### PR DESCRIPTION
## Summary

- Replace `PAT_TOKEN` with `GITHUB_TOKEN` for release-please
- Remove unused `packages: write` permission
- Add `permissions: contents: read` to CI workflow

## Test plan

- [ ] Verify release workflow still creates releases and uploads signed JARs
- [x] Enable "Allow GitHub Actions to create and approve pull requests" in org settings
