### PR TITLE
chore(keycloak): update default version references from 26.5.2 to 26.5.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           - "26.2.5"
           - "26.3.5"
           - "26.4.7"
-          - "26.5.2"
+          - "26.5.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -36,7 +36,7 @@ jobs:
           - "26.2.5"
           - "26.3.5"
           - "26.4.7"
-          - "26.5.2"
+          - "26.5.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the following to your Dockerfile:
 ```dockerfile
 # Download and install the authenticator
 ARG ORG_USERNAME_FIX_VERSION="v1.1.3" # x-release-please-version
-ARG ORG_USERNAME_FIX_KC_VERSION="26.5.2"
+ARG ORG_USERNAME_FIX_KC_VERSION="26.5.4"
 ADD https://github.com/for-keycloak/keycloak-spi-fix-organization-username-form/releases/download/${ORG_USERNAME_FIX_VERSION}/fix-organization-username-form-${ORG_USERNAME_FIX_VERSION}-kc-${ORG_USERNAME_FIX_KC_VERSION}.jar \
     /opt/keycloak/providers/fix-organization-username-form.jar
 ```
@@ -82,7 +82,7 @@ The authenticator is built and tested with multiple Keycloak versions:
 
 | Keycloak Version |
 |------------------|
-| 26.5.2           |
+| 26.5.4           |
 | 26.4.7           |
 | 26.3.5           |
 | 26.2.5           |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:26.5.3
+    image: quay.io/keycloak/keycloak:26.5.4
     environment:
       # Admin console credentials
       KEYCLOAK_ADMIN: admin
@@ -18,7 +18,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./target/fix-organization-username-form-dev-kc-26.5.2.jar:/opt/keycloak/providers/fix-organization-username-form.jar
+      - ./target/fix-organization-username-form-dev-kc-26.5.4.jar:/opt/keycloak/providers/fix-organization-username-form.jar
     command: start-dev
 
   postgres:

--- a/e2e/compose.yaml
+++ b/e2e/compose.yaml
@@ -1,6 +1,6 @@
 services:
   keycloak-main:
-    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.5.2}
+    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.5.4}
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin
@@ -9,7 +9,7 @@ services:
       KC_DB_USERNAME: keycloak
       KC_DB_PASSWORD: keycloak
     volumes:
-      - ../target/fix-organization-username-form-dev-kc-${KC_VERSION:-26.5.2}.jar:/opt/keycloak/providers/fix-organization-username-form.jar
+      - ../target/fix-organization-username-form-dev-kc-${KC_VERSION:-26.5.4}.jar:/opt/keycloak/providers/fix-organization-username-form.jar
       - ./setup/main-realm.json:/opt/keycloak/data/import/realm.json
     command: start-dev --import-realm
     depends_on:
@@ -22,7 +22,7 @@ services:
       retries: 30
 
   keycloak-idp:
-    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.5.2}
+    image: quay.io/keycloak/keycloak:${KC_VERSION:-26.5.4}
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin

--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ setup:
 # List all available Keycloak versions
 versions:
     @echo "Supported Keycloak versions:"
-    @echo "- 26.5.2 (default)"
+    @echo "- 26.5.4 (default)"
     @echo "- 26.4.7"
     @echo "- 26.3.5"
     @echo "- 26.2.5"

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <buildVersion>dev</buildVersion>
 
         <!-- Default Keycloak version -->
-        <keycloak.version>26.5.3</keycloak.version>
+        <keycloak.version>26.5.4</keycloak.version>
 
         <!-- Dependency versions -->
         <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>


### PR DESCRIPTION
## Summary

Updates all remaining references of Keycloak `26.5.2` to `26.5.4` to align with the dependency bump already applied in `pom.xml`.


## Changes

- **README.md** - Dockerfile example, supported versions table
- **justfile** - versions list
- **docker-compose.yaml** - JAR volume mount path
- **e2e/compose.yaml** - Default image tag and JAR path
- **.github/workflows/release-please.yaml** - Build matrix
- **.github/workflows/ci.yaml** - Build and test matrix
